### PR TITLE
Staticman comments error

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -139,8 +139,8 @@ google_analytics: "UA-139907761-1"
 
 # Staticman support
 staticman:
-  repository : Roothash41/Roothash41.github.io# GitHub username/repository eg. "daattali/beautiful-jekyll"
-  branch     : master# eg. "master" If you're not using `master` branch, then you also need to update the `branch` parameter in `staticman.yml`
+  repository : Roothash41/Roothash41.github.io # GitHub username/repository eg. "daattali/beautiful-jekyll"
+  branch     : master # eg. "master" If you're not using `master` branch, then you also need to update the `branch` parameter in `staticman.yml`
   endpoint   : # URL of your own deployment (with trailing slash) (will fallback to a public GitLab instance)
   reCaptcha:
     # reCaptcha for Staticman (OPTIONAL)

--- a/_posts/2019-05-09-new-article.md
+++ b/_posts/2019-05-09-new-article.md
@@ -6,7 +6,7 @@ image: /img/Mario.png
 tags: [wish, love]
 ---
 
-**I build this page to you.**
+**I build this page for you.**
 
 ### Smile to me 
 


### PR DESCRIPTION
# :speech_balloon:
Hi this is the maintainer of @staticmanlab.  I've encountered error when trying to leave a comment on your site.  I can't find anything wrong in your configurations.  Have you accepted the invitation by step #1 below?

# :frowning_woman: Inconvenience of comments stored in databases

:frowning: I'm not familiar with the actual procedures with FB comments.  On [my old GitHub pages + Octopress site](//git.io/vtblog), i used Disqus, but URL refactoring can lead to disappearance of comments.  Changing the URL is complicated.  Having LaTeX inside comments is impossible... Users don't own their comments.

[![Disqus screenshot](https://screenshotscdn.firefoxusercontent.com/images/380d5c94-d3d3-4aca-916e-6a777c8700ce.png)](https://vincenttam.github.io/blog/2017/01/28/moved-to-octopress-3/#disqus_thread)  
Figure: Disqus on [my old GitHub pages + Octopress site](//git.io/vtblog)

# :question: Why go static?

:globe_with_meridians: Static comments on my current [Hugo + Staticman + KaTeX GitLab pages](https://vincenttam.gitlab.io/):  
[![Staticman comment reply](https://screenshotscdn.firefoxusercontent.com/images/1bae706e-d523-41b3-98ab-ce2041d7fab5.png)](https://vincenttam.gitlab.io/post/2018-12-24-staticman-on-framagit/#comment-1)  
Figure: [Staticman](//staticman.net) comments with the theme Beautiful Hugo provided by halogenica/beautifulhugo#222

:bulb: What does "owning my comments" mean?  You can do *whatever* you want with it.  
[![Staticman + KaTeX + Beautiful Hugo](https://screenshotscdn.firefoxusercontent.com/images/c64e8252-7dae-45d5-9cf4-47de4e4a4fc0.png)](https://staticman-gitlab-pages.frama.io/bhdemo/posts/my-second-post/)  
Figure: math in comments

:1234: Static comments are treated like the site's static content, so you can use [KaTeX](https://katex.org/) for math display.

:heavy_check_mark: I ported others [Staticman](//staticman.net) integration code to some Jekyll and Hugo templates.

# :construction_worker_man: Staticman Configurations for Beautiful Jekyll

:email: Please don't hesitate to ping me on GitHub/GitLab/leave a comment on my blog/send me an email to ask for help.

1. :checkered_flag: Invite @staticmanlab as a collaborator to your repository (by going to your repository Settings page, navigate to the Collaborators tab).  
![send invitation to Staticman Lab](https://git.io/fjZPx)  
Image short link: https://git.io/fjZPx
2. :ballot_box_with_check: Help @staticmanlab accept the invitation by going to

        https://staticman3.herokuapp.com/v3/connect/github/<username>/<repo-name>

    In your case, that's

        https://staticman3.herokuapp.com/v3/connect/github/<username>/<repo-name>

    ![Staticman Lab invitation accepted](https://camo.githubusercontent.com/fca08dcc33537c78f0b56e934afde4af0605f706/68747470733a2f2f76696e63656e7474616d2e6769746c61622e696f2f706f73742f323031382d31322d31392d7374617469636d616e2d696e7669746174696f6e2d69732d636173652d73656e7369746976652f696e76697465322e706e67)  
    Figure: image showing setup for [my fork of this theme](//git.io/bjsm0)  
    Image short link: https://git.io/fjZXG

    ![Staticman Lab shown as collaborator](https://camo.githubusercontent.com/eb3d86ecf35497912c485fb2d339d9d3cd962197/68747470733a2f2f76696e63656e7474616d2e6769746c61622e696f2f706f73742f323031382d31322d31392d7374617469636d616e2d696e7669746174696f6e2d69732d636173652d73656e7369746976652f696e76697465332e706e67)  
    Figure: @staticmanlab invited to GitHub repo  
    Image short link: https://git.io/fjZXZ

3. :writing_hand: Fill in your `repository` and `branch` in the Staticman section of `_config.yml`.

    ```yml
     # Staticman support 
     staticman: 
       repository : "<username>/<repo-name>" # GitHub username/repository eg. "daattali/beautiful-jekyll" 
       branch     : "master" # eg. "master" If you're not using `master` branch, then you also need to update the `branch` parameter in `staticman.yml` 
       endpoint   : # URL of your own deployment (with trailing slash) (will fallback to a public GitLab instance) 
       reCaptcha: 
         # reCaptcha for Staticman (OPTIONAL) 
         # If you use reCaptcha, you must also set these parameters in staticman.yml 
         siteKey  : # Use your own site key, you need to apply for one on Google 
    secret   : # ENCRYPT your password by going to https://staticman3.herokuapp.com/v3/encrypt/<your-site-secret> 
    ```

4. :memo: Start commenting.